### PR TITLE
Cargo: minor version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_coin_select"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 #rust-version = "1.54"
 homepage = "https://bitcoindevkit.org"


### PR DESCRIPTION
If you don't mind making a release to make the `println!()`s removal (#8) available through crates.io.