### PR TITLE
fix: add excess to changeless `LowestFee` score

### DIFF
--- a/src/metrics/lowest_fee.rs
+++ b/src/metrics/lowest_fee.rs
@@ -35,12 +35,12 @@ where
     fn calc_metric(&self, cs: &CoinSelector<'_>, drain_weights: Option<DrainWeights>) -> f32 {
         self.calc_metric_lb(cs, drain_weights)
             + match drain_weights {
-                Some(_) => {
+                Some(_) => 0.0,
+                None => {
                     let selected_value = cs.selected_value();
                     assert!(selected_value >= self.target.value);
                     (cs.selected_value() - self.target.value) as f32
                 }
-                None => 0.0,
             }
     }
 

--- a/tests/lowest_fee.rs
+++ b/tests/lowest_fee.rs
@@ -156,6 +156,6 @@ fn combined_changeless_metric() {
         common::bnb_search(&mut cs_b, metric_combined, usize::MAX).expect("must find solution");
     println!("score={:?} rounds={}", combined_score, combined_rounds);
 
-    // [todo] shouldn't rounds be less since we are only considering changeless branches?
-    assert!(combined_rounds <= rounds);
+    // rounds is less since combined only considers changeless branches
+    assert!(rounds <= combined_rounds);
 }


### PR DESCRIPTION
This is to fix the part of #6 relating to https://github.com/bitcoindevkit/bdk/pull/1072#discussion_r1393687511.

For the `LowestFee` metric, it adds the excess to changeless solutions instead of those with change.