### PR TITLE
Loosen LowestFee metric bound

### DIFF
--- a/src/feerate.rs
+++ b/src/feerate.rs
@@ -79,10 +79,15 @@ impl FeeRate {
         self.0 .0
     }
 
-    /// The fee that the transaction with weight `tx_weight` should pay in order to satisfy the fee rate given by `self`.
+    /// The fee that the transaction with weight `tx_weight` should pay in order to satisfy the fee rate given by `self`,
+    /// where the fee rate is applied to the rounded-up vbytes obtained from `tx_weight`.
     pub fn implied_fee(&self, tx_weight: u64) -> u64 {
-        // The fee rate is applied to the rounded-up vbytes.
         ((tx_weight as f32 / 4.0).ceil() * self.as_sat_vb()).ceil() as u64
+    }
+
+    /// Same as [implied_fee](Self::implied_fee) except the fee rate given by `self` is applied to `tx_weight` directly.
+    pub fn implied_fee_wu(&self, tx_weight: u64) -> u64 {
+        (tx_weight as f32 * self.spwu()).ceil() as u64
     }
 }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -141,4 +141,13 @@ impl Replace {
                 .incremental_relay_feerate
                 .implied_fee(replacing_tx_weight)
     }
+
+    /// Same as (min_fee_to_do_replacement)[Self::min_fee_to_do_replacement] except the additional fee
+    /// is calculated using `replacing_tx_weight` directly without any conversion to vbytes.
+    pub fn min_fee_to_do_replacement_wu(&self, replacing_tx_weight: u64) -> u64 {
+        self.fee
+            + self
+                .incremental_relay_feerate
+                .implied_fee_wu(replacing_tx_weight)
+    }
 }

--- a/tests/lowest_fee.proptest-regressions
+++ b/tests/lowest_fee.proptest-regressions
@@ -10,3 +10,4 @@ cc c580ee452624915fc710d5fe724c7a9347472ccd178f66c9db9479cfc6168f48 # shrinks to
 cc 850e0115aeeb7ed50235fdb4b5183eb5bf8309a45874dc261e3d3fd2d8c84660 # shrinks to n_candidates = 8, target_value = 444541, base_weight = 253, min_fee = 0, feerate = 55.98181, feerate_lt_diff = 36.874306, drain_weight = 490, drain_spend_weight = 1779, drain_dust = 100
 cc ca9831dfe4ad27fc705ae4af201b9b50739404bda0e1e130072858634f8d25d9 # added by llfourn from ci: has a case where the lowest fee metric would benefit by adding change
 cc 85d9dc968a690553484d0f166f3d778c3e0ec7d9059809c2818b62d6609853c1
+cc b32bb279f62e2300a14c9053cff09f6a953bf1020b878958cb510258ffe65028 # added by jp1ac4 from ci


### PR DESCRIPTION
The change in #29 led to the `LowestFee` metric lower bound being too tight, as found in the CI failure:
https://github.com/bitcoindevkit/coin-select/actions/runs/11584669281/job/32252247886

This PR tries to loosen the bound by assuming that no rounding up will be required when converting from weight units to vbytes, which would be the best-case scenario.