### PR TITLE
fix: add conditional FloatExt import for no_std builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix compilation error when building with `--no-default-features` (#36)
+
 # 0.4.0
 
 - Use `u64` for weights instead of u32

--- a/src/feerate.rs
+++ b/src/feerate.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use crate::float::FloatExt;
 use crate::float::Ordf32;
 use core::ops::{Add, Sub};
 


### PR DESCRIPTION

Fixes compilation error when building with `--no-default-features` by adding a conditional import of the `FloatExt` trait in `feerate.rs`.


* [x] I've signed all my commits
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] CHANGELOG.md updated

Fixes #36 