### PR TITLE
Fix tuple BnB metric ordering propagation

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -65,7 +65,7 @@ macro_rules! impl_for_tuple {
             }
             #[allow(unused)]
             fn requires_ordering_by_descending_value_pwu(&self) -> bool {
-                [$(self.$b.0.requires_ordering_by_descending_value_pwu()),*].iter().all(|x| *x)
+                [$(self.$b.0.requires_ordering_by_descending_value_pwu()),*].iter().any(|x| *x)
             }
         }
     };

--- a/tests/bnb.rs
+++ b/tests/bnb.rs
@@ -52,6 +52,36 @@ impl BnbMetric for MinExcessThenWeight {
     }
 }
 
+#[derive(Clone, Copy)]
+struct OrderSensitive;
+
+impl BnbMetric for OrderSensitive {
+    fn score(&mut self, _cs: &CoinSelector<'_>) -> Option<Ordf32> {
+        Some(Ordf32(0.0))
+    }
+
+    fn bound(&mut self, _cs: &CoinSelector<'_>) -> Option<Ordf32> {
+        Some(Ordf32(0.0))
+    }
+
+    fn requires_ordering_by_descending_value_pwu(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Clone, Copy)]
+struct NoOrderMetric;
+
+impl BnbMetric for NoOrderMetric {
+    fn score(&mut self, _cs: &CoinSelector<'_>) -> Option<Ordf32> {
+        Some(Ordf32(0.0))
+    }
+
+    fn bound(&mut self, _cs: &CoinSelector<'_>) -> Option<Ordf32> {
+        Some(Ordf32(0.0))
+    }
+}
+
 #[test]
 /// Detect regressions/improvements by making sure it always finds the solution in the same
 /// number of iterations.
@@ -137,6 +167,24 @@ fn bnb_finds_solution_if_possible_in_n_iter() {
     assert_eq!(rounds, 164);
     let excess = sol.excess(target, Drain::NONE);
     assert_eq!(excess, 0);
+}
+
+#[test]
+fn bnb_tuple_metric_respects_ordering_requirement() {
+    assert!(
+        ((OrderSensitive, 1.0), (OrderSensitive, 1.0)).requires_ordering_by_descending_value_pwu(),
+        "both require ordering, so ordering should be required"
+    );
+
+    assert!(
+        ((OrderSensitive, 1.0), (NoOrderMetric, 1.0)).requires_ordering_by_descending_value_pwu(),
+        "one requires ordering, so ordering should be required"
+    );
+
+    assert!(
+        !((NoOrderMetric, 1.0), (NoOrderMetric, 1.0)).requires_ordering_by_descending_value_pwu(),
+        "none require ordering, so ordering should not be required"
+    );
 }
 
 proptest! {


### PR DESCRIPTION
Tuple BnB metrics currently propagates `requires_ordering_by_descending_value_pwu()` using `all()`. 

If one metric requires descending order and another does not, order is skipped, thus violating the requirement of the order-dependent metrics.

What this PR does:

1. Adds a test (`bnb_tuple_metric_respects_ordering_requirement`) demonstrating the issue.

2. The fix involves changing the ordering propagation to use any() instead of all().

The test is added in a separate commit to clearly demonstrate the failing behavior before the fix.