### PR TITLE
chore: ignore perf.data and .claude/ artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /Cargo.lock
+perf.data*
+.claude/


### PR DESCRIPTION
Ignore local artifacts that shouldn't be tracked:

- `perf.data*` — `perf` profiling output
- `.claude/` — Claude Code's working directory

Keeps a stray `git add -A` from picking them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)